### PR TITLE
feat: Restore Docker utility scripts per Fade's request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ Thumbs.db
 
 # Shell scripts (exclude from repository)
 *.sh
+# Exception: Docker utility scripts should be included
+!docker/start.sh
+!docker/stop.sh

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Simple start script for Docker directory
+# Run from: /home/glenn/Projects/Code/asteroid/docker/
+
+echo "🎵 Starting Asteroid Radio Docker Services..."
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+    echo "❌ Docker is not running. Please start Docker first."
+    exit 1
+fi
+
+# Start services
+echo "🔧 Starting services..."
+docker compose up -d
+
+# Wait and show status
+sleep 3
+echo ""
+echo "📊 Service Status:"
+docker compose ps
+
+echo ""
+echo "🎵 Asteroid Radio is now streaming!"
+echo "📡 High Quality: http://localhost:8000/asteroid.mp3"
+echo "📡 Low Quality:  http://localhost:8000/asteroid-low.mp3"
+echo "🔧 Admin Panel:  http://localhost:8000/admin/"

--- a/docker/stop.sh
+++ b/docker/stop.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Simple stop script for Docker directory
+# Run from: /home/glenn/Projects/Code/asteroid/docker/
+
+echo "🛑 Stopping Asteroid Radio Docker Services..."
+
+# Stop services
+docker compose down
+
+echo ""
+echo "✅ Services stopped."


### PR DESCRIPTION
- Add docker/start.sh and docker/stop.sh back to repository
- Update .gitignore to allow these specific Docker utility scripts
- These scripts provide convenient Docker Compose management
- Maintains general *.sh exclusion while allowing essential Docker scripts