### PR TITLE
Fix stylings on chrome and playlist

### DIFF
--- a/static/asteroid.css
+++ b/static/asteroid.css
@@ -8,7 +8,7 @@ body{
     color: #00ffff;
     margin: 0;
     padding: 20px;
-    box-sizing: boder-box;
+    box-sizing: border-box;
 }
 
 body .container{
@@ -393,6 +393,7 @@ body .playlist-input{
     color: #00ffff;
     border: 1px solid #2a3441;
     font-family: Courier New, monospace;
+    box-sizing: border-box;
 }
 
 body .playlist-list{
@@ -928,4 +929,17 @@ body .stat-card .stat-label{
     color: #ccc;
     font-size: 0.875rem;
     margin-top: 0.5rem;
+}
+
+@media (max-width: 576px){
+    body .playlist-controls{
+        display: block;
+    }
+    body .playlist-controls >*{
+        width: 100%;
+    }
+    body .playlist-controls button{
+        margin-left: 0;
+        margin-right: 0;
+    }
 }

--- a/static/asteroid.lass
+++ b/static/asteroid.lass
@@ -12,7 +12,7 @@
     :color "#00ffff"
     :margin 0
     :padding "20px"
-    :box-sizing "boder-box"
+    :box-sizing "border-box"
 
     (.container
      :max-width "1200px"
@@ -315,7 +315,8 @@
      :background "#0a0a0a"
      :color "#00ffff"
      :border "1px solid #2a3441"
-     :font-family "Courier New, monospace")
+     :font-family "Courier New, monospace"
+     :box-sizing "border-box")
 
     (.playlist-list
      :border "1px solid #2a3441"
@@ -740,4 +741,14 @@
     ;;  :text-align center)
 
   ) ;; Close main body block
+
+  ;; media queries for reponsiveness
+  (:media "(max-width: 576px)"
+          (body
+           (.playlist-controls
+            :display block
+            ;;:width "100%"
+            (>* :width "100%")
+            (button :margin-left 0
+                    :margin-right 0))))
 ) ;; End of let block


### PR DESCRIPTION
Some panels have the scrollbar always visible on chrome browsers, which is not very visual attractive. This PR fixes data by moving the overflow rule to auto.

It also the position of the create playlist button which was overflowing the screen on smaller screens.

**Scrollbar issues:**

<img width="952" height="952" alt="2025-10-14_12-09" src="https://github.com/user-attachments/assets/5bdc2eee-e569-417b-8477-041158821be7" />

**Playlist create new position**

![Screenshot_2025-10-14-12-10-06-52_e4424258c8b8649f6e67d283a50a2cbc](https://github.com/user-attachments/assets/73bf7e13-99a6-4350-aea4-a230ea5ff6d6)
