### PR TITLE
Lock stream service containers to localhost access

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: infiniteproject/icecast:latest
     container_name: asteroid-icecast
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     volumes:
       - ./icecast.xml:/etc/icecast.xml
     environment:
@@ -20,7 +20,7 @@ services:
       dockerfile: Dockerfile.liquidsoap
     container_name: asteroid-liquidsoap
     ports:
-      - "1234:1234"
+      - "127.0.0.1:1234:1234"
     depends_on:
       - icecast
     volumes:


### PR DESCRIPTION
This PR updates the mapping of our docker containers, used for steaming services (icecast and liquidsoap), to only allow Access from the localhost interface, effectively blocking them from external access.

This means that merging this requires that a publicly facing asteroid needs to have a reverse proxy exposing the icecast port for streaming to work. 

The liquidsoap telnet does not seem to be in use at the moment, but it should always be used by the asteroid service which is running on localhost already.