### PR TITLE
security: Remove hardcoded admin credentials from login page

### DIFF
--- a/template/login.ctml
+++ b/template/login.ctml
@@ -37,11 +37,6 @@
             <button type="submit" class="btn btn-primary" style="width: 100%;">LOGIN</button>
           </div>
         </form>
-        <div class="panel" style="margin-top: 20px; text-align: center;">
-          <strong style="color: #ff6600;">Default Admin Credentials:</strong><br>
-          Username: <br><code style="color: #00ff00;">admin</code><br>
-          Password: <br><code style="color: #00ff00;">asteroid123</code>
-        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Removed the display of default admin username and password from the login page template. This information should not be publicly visible as it poses a security risk in production environments.

Administrators should use secure credential management practices and change default passwords during initial setup.