### PR TITLE
feat: Add password management and fix listener count

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: infiniteproject/icecast:latest
     container_name: asteroid-icecast
     ports:
-      - "127.0.0.1:8000:8000"
+      - "${ICECAST_BIND:-127.0.0.1}:8000:8000"
     volumes:
       - ./icecast.xml:/etc/icecast.xml
     environment:

--- a/frontend-partials.lisp
+++ b/frontend-partials.lisp
@@ -1,6 +1,11 @@
 (in-package :asteroid)
 
 (defun icecast-now-playing (icecast-base-url)
+  "Fetch now-playing information from Icecast server.
+  
+  ICECAST-BASE-URL - Base URL of the Icecast server (e.g. http://localhost:8000)
+  
+  Returns a plist with :listenurl, :title, and :listeners, or NIL on error."
     (let* ((icecast-url (format nil "~a/admin/stats.xml" icecast-base-url))
            (response (drakma:http-request icecast-url
                                          :want-stream nil
@@ -9,29 +14,32 @@
           (let ((xml-string (if (stringp response)
                                 response
                                 (babel:octets-to-string response :encoding :utf-8))))
-            ;; Simple XML parsing to extract source information
-            ;; Look for <source mount="/asteroid.mp3"> sections and extract title, listeners, etc.
-            (multiple-value-bind (match-start match-end)
-                (cl-ppcre:scan "<source mount=\"/asteroid\\.mp3\">" xml-string)
-
-              (if match-start
-                  (let* ((source-section (subseq xml-string match-start
-                                                 (or (cl-ppcre:scan "</source>" xml-string :start match-start)
-                                                     (length xml-string))))
-                         (titlep (cl-ppcre:all-matches "<title>" source-section))
-                         (listenersp (cl-ppcre:all-matches "<listeners>" source-section))
-                         (title (if titlep (cl-ppcre:regex-replace-all ".*<title>(.*?)</title>.*" source-section "\\1") "Unknown"))
-                         (listeners (if listenersp (cl-ppcre:regex-replace-all ".*<listeners>(.*?)</listeners>.*" source-section "\\1") "0")))
-                    `((:listenurl . ,(format nil "~a/asteroid.mp3" *stream-base-url*))
-                      (:title . ,title)
-                      (:listeners . ,(parse-integer listeners :junk-allowed t))))
-                  `((:listenurl . ,(format nil "~a/asteroid.mp3" *stream-base-url*))
-                    (:title . "Unknown")
-                    (:listeners . "Unknown"))))))))
+            ;; Extract total listener count from root <listeners> tag (sums all mount points)
+            ;; Extract title from asteroid.mp3 mount point
+            (let* ((total-listeners (multiple-value-bind (match groups)
+                                        (cl-ppcre:scan-to-strings "<listeners>(\\d+)</listeners>" xml-string)
+                                      (if (and match groups)
+                                          (parse-integer (aref groups 0) :junk-allowed t)
+                                          0)))
+                   ;; Get title from asteroid.mp3 mount point
+                   (mount-start (cl-ppcre:scan "<source mount=\"/asteroid\\.mp3\">" xml-string))
+                   (title (if mount-start
+                             (let* ((source-section (subseq xml-string mount-start
+                                                           (or (cl-ppcre:scan "</source>" xml-string :start mount-start)
+                                                               (length xml-string)))))
+                               (multiple-value-bind (match groups)
+                                   (cl-ppcre:scan-to-strings "<title>(.*?)</title>" source-section)
+                                 (if (and match groups)
+                                     (aref groups 0)
+                                     "Unknown")))
+                             "Unknown")))
+              `((:listenurl . ,(format nil "~a/asteroid.mp3" *stream-base-url*))
+                (:title . ,title)
+                (:listeners . ,total-listeners)))))))
 
 (define-api asteroid/partial/now-playing () ()
   "Get Partial HTML with live status from Icecast server"
-  (handler-case
+  (with-error-handling
     (let ((now-playing-stats (icecast-now-playing *stream-base-url*)))
       (if now-playing-stats
           (progn
@@ -46,15 +54,11 @@
             (clip:process-to-string
              (load-template "partial/now-playing")
              :connection-error t
-             :stats nil))))
-    (error (e)
-      (api-output `(("status" . "error")
-                    ("message" . ,(format nil "Error loading profile: ~a" e)))
-                  :status 500))))
+             :stats nil))))))
 
 (define-api asteroid/partial/now-playing-inline () ()
   "Get inline text with now playing info (for admin dashboard and widgets)"
-  (handler-case
+  (with-error-handling
     (let ((now-playing-stats (icecast-now-playing *stream-base-url*)))
       (if now-playing-stats
           (progn
@@ -62,7 +66,4 @@
             (cdr (assoc :title now-playing-stats)))
           (progn
             (setf (header "Content-Type") "text/plain")
-            "Stream Offline")))
-    (error (e)
-      (setf (header "Content-Type") "text/plain")
-      "Error loading stream info")))
+            "Stream Offline")))))

--- a/static/js/profile.js
+++ b/static/js/profile.js
@@ -296,3 +296,54 @@ function showMessage(message, type = 'info') {
 function showError(message) {
     showMessage(message, 'error');
 }
+
+// Password change handler
+function changePassword(event) {
+    event.preventDefault();
+    
+    const currentPassword = document.getElementById('current-password').value;
+    const newPassword = document.getElementById('new-password').value;
+    const confirmPassword = document.getElementById('confirm-password').value;
+    const messageDiv = document.getElementById('password-message');
+    
+    // Client-side validation
+    if (newPassword.length < 8) {
+        messageDiv.textContent = 'New password must be at least 8 characters';
+        messageDiv.className = 'message error';
+        return false;
+    }
+    
+    if (newPassword !== confirmPassword) {
+        messageDiv.textContent = 'New passwords do not match';
+        messageDiv.className = 'message error';
+        return false;
+    }
+    
+    // Send request to API
+    const formData = new FormData();
+    formData.append('current-password', currentPassword);
+    formData.append('new-password', newPassword);
+    
+    fetch('/api/asteroid/user/change-password', {
+        method: 'POST',
+        body: formData
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.status === 'success' || (data.data && data.data.status === 'success')) {
+            messageDiv.textContent = 'Password changed successfully!';
+            messageDiv.className = 'message success';
+            document.getElementById('change-password-form').reset();
+        } else {
+            messageDiv.textContent = data.message || data.data?.message || 'Failed to change password';
+            messageDiv.className = 'message error';
+        }
+    })
+    .catch(error => {
+        console.error('Error changing password:', error);
+        messageDiv.textContent = 'Error changing password';
+        messageDiv.className = 'message error';
+    });
+    
+    return false;
+}

--- a/stream-control.lisp
+++ b/stream-control.lisp
@@ -77,8 +77,7 @@
     (if (and (stringp host-path) 
              (>= (length host-path) (length library-prefix))
              (string= host-path library-prefix :end1 (length library-prefix)))
-        (concatenate 'string "/app/music/" 
-                    (subseq host-path (length library-prefix)))
+        (format nil "/app/music/~a" (subseq host-path (length library-prefix)))
         host-path)))
 
 (defun generate-m3u-playlist (track-ids output-path)
@@ -183,9 +182,9 @@
   (if (and (stringp docker-path)
            (>= (length docker-path) 11)
            (string= docker-path "/app/music/" :end1 11))
-      (concatenate 'string 
-                   (namestring *music-library-path*)
-                   (subseq docker-path 11))
+      (format nil "~a~a" 
+              (namestring *music-library-path*)
+              (subseq docker-path 11))
       docker-path))
 
 (defun load-queue-from-m3u-file ()

--- a/template/admin.ctml
+++ b/template/admin.ctml
@@ -166,11 +166,82 @@
         <div class="controls">
           <a href="/asteroid/admin/users" class="btn btn-primary">👥 Manage Users</a>
         </div>
+        
+        <!-- Admin Password Reset Form -->
+        <div class="form-section" style="margin-top: 20px;">
+          <h4>🔒 Reset User Password</h4>
+          <form id="admin-reset-password-form" onsubmit="return resetUserPassword(event)">
+            <div class="form-group">
+              <label for="reset-username">Username:</label>
+              <input type="text" id="reset-username" name="username" required>
+            </div>
+            <div class="form-group">
+              <label for="reset-new-password">New Password:</label>
+              <input type="password" id="reset-new-password" name="new-password" required minlength="8">
+            </div>
+            <div class="form-group">
+              <label for="reset-confirm-password">Confirm Password:</label>
+              <input type="password" id="reset-confirm-password" name="confirm-password" required minlength="8">
+            </div>
+            <div id="reset-password-message" class="message"></div>
+            <button type="submit" class="btn btn-primary">Reset Password</button>
+          </form>
+        </div>
       </div>
     </div>
   </div>
 
   <script>
+    // Admin password reset handler
+    function resetUserPassword(event) {
+      event.preventDefault();
+      
+      const username = document.getElementById('reset-username').value;
+      const newPassword = document.getElementById('reset-new-password').value;
+      const confirmPassword = document.getElementById('reset-confirm-password').value;
+      const messageDiv = document.getElementById('reset-password-message');
+      
+      // Client-side validation
+      if (newPassword.length < 8) {
+        messageDiv.textContent = 'New password must be at least 8 characters';
+        messageDiv.className = 'message error';
+        return false;
+      }
+      
+      if (newPassword !== confirmPassword) {
+        messageDiv.textContent = 'Passwords do not match';
+        messageDiv.className = 'message error';
+        return false;
+      }
+      
+      // Send request to API
+      const formData = new FormData();
+      formData.append('username', username);
+      formData.append('new-password', newPassword);
+      
+      fetch('/api/asteroid/admin/reset-password', {
+        method: 'POST',
+        body: formData
+      })
+      .then(response => response.json())
+      .then(data => {
+        if (data.status === 'success' || (data.data && data.data.status === 'success')) {
+          messageDiv.textContent = 'Password reset successfully for user: ' + username;
+          messageDiv.className = 'message success';
+          document.getElementById('admin-reset-password-form').reset();
+        } else {
+          messageDiv.textContent = data.message || data.data?.message || 'Failed to reset password';
+          messageDiv.className = 'message error';
+        }
+      })
+      .catch(error => {
+        console.error('Error resetting password:', error);
+        messageDiv.textContent = 'Error resetting password';
+        messageDiv.className = 'message error';
+      });
+      
+      return false;
+    }
   </script>
 </body>
 </html>

--- a/template/profile.ctml
+++ b/template/profile.ctml
@@ -153,6 +153,28 @@
     <!-- Profile Actions -->
     <div class="admin-section">
         <h2>⚙️ Profile Settings</h2>
+        
+        <!-- Change Password Form -->
+        <div class="form-section">
+          <h3>🔒 Change Password</h3>
+          <form id="change-password-form" onsubmit="return changePassword(event)">
+            <div class="form-group">
+              <label for="current-password">Current Password:</label>
+              <input type="password" id="current-password" name="current-password" required minlength="8">
+            </div>
+            <div class="form-group">
+              <label for="new-password">New Password:</label>
+              <input type="password" id="new-password" name="new-password" required minlength="8">
+            </div>
+            <div class="form-group">
+              <label for="confirm-password">Confirm New Password:</label>
+              <input type="password" id="confirm-password" name="confirm-password" required minlength="8">
+            </div>
+            <div id="password-message" class="message"></div>
+            <button type="submit" class="btn btn-primary">Change Password</button>
+          </form>
+        </div>
+        
         <div class="profile-actions">
           <button class="btn btn-primary" onclick="editProfile()">✏️ Edit Profile</button>
           <button class="btn btn-secondary" onclick="exportListeningData()">📊 Export Data</button>


### PR DESCRIPTION
# Add password management and fix listener count

## Changes
- **Password Management**: Added UI and API for users to change passwords and admins to reset passwords (blocked by LambdaLite bug - see known issues)
- **Listener Count Fix**: Now correctly reads total from Icecast root `<listeners>` tag
- **Style Improvements**: Replaced `concatenate` with `format`, added `with-error-handling` to API endpoints
- **Docker Config**: Made Icecast port binding configurable via `ICECAST_BIND` env var (defaults to `127.0.0.1`)

## Known Issues
Password reset UI/API implemented but non-functional due to LambdaLite `db:update` bug with `password-hash` field. Issue has been reported.

## Local Dev Setup
Create `docker/.env`:
```bash
ICECAST_BIND=0.0.0.0
```