### PR TITLE
Fix: Database Schema Typos and Logging

### DIFF
--- a/database.lisp
+++ b/database.lisp
@@ -45,5 +45,5 @@
   ;; (unless (db:collection-exists-p "sessions")
   ;;   (db:create "sessions" '(())))
   
-  (l:info "~2&Database collections initialized~%"))
+  (format t "~2&Database collections initialized~%"))
 


### PR DESCRIPTION
## Summary
Fixes typos in the database schema that were introduced during upstream merge, and corrects a logging statement.

## Changes

### Database Schema Fixes (`database.lisp`)

1. **Fixed typo in `playlist_tracks` schema**
   - Changed `position :ingeger` → `position :integer`
   - This typo would cause database creation to fail

2. **Standardized date field type**
   - Changed `added_date :timestamp` → `added_date :integer`
   - Maintains consistency with other date fields in the schema (e.g., `created-date`, `last-login` in USERS table)
   - All date fields use Unix timestamps stored as integers

3. **Fixed logging statement**
   - Changed `(l:info "~2&Database collections initialized~%")` → `(format t "~2&Database collections initialized~%")`
   - The `l:info` function doesn't exist in the current logging setup
   - Uses standard `format t` for consistency with other initialization messages

## Testing

- [x] Database initialization completes without errors
- [x] All collections created successfully
- [x] No runtime errors from logging statement

## Related Issues

These fixes address bugs introduced during the upstream merge that would prevent proper database initialization.

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are minimal and focused
- [x] No breaking changes
- [x] Tested locally
