### PR TITLE
fix: Use sequential mode in liquidsoap to play through entire playlist

### DIFF
--- a/docker/asteroid-radio-docker.liq
+++ b/docker/asteroid-radio-docker.liq
@@ -23,9 +23,9 @@ settings.server.telnet.bind_addr.set("0.0.0.0")
 # This file is managed by Asteroid's stream control system
 # Falls back to directory scan if playlist file doesn't exist
 radio = playlist(
-  mode="normal",  # Play in order (not randomized)
-  reload=30,      # Check for playlist updates every 30 seconds
-  reload_mode="seconds",  # Reload every N seconds (prevents running out of tracks)
+  mode="sequential",  # Play through playlist in order, then loop
+  reload=300,         # Check for playlist updates every 5 minutes
+  reload_mode="watch",  # Watch file for changes (more efficient than polling)
   "/app/stream-queue.m3u"
 )
 


### PR DESCRIPTION
## Problem
The playlist was getting stuck on the first track and looping indefinitely. Liquidsoap was restarting the playlist every 30 seconds instead of advancing through the tracks.

## Root Cause
The `mode="normal"` setting in the `playlist()` function causes liquidsoap to play tracks once and stop. Combined with the frequent `reload=30` polling, this resulted in the playlist constantly restarting from the beginning.

## Solution
Changed the playlist configuration to:
- **`mode="sequential"`** - Plays through the entire playlist in order, then loops back to the beginning
- **`reload_mode="watch"`** - Uses filesystem watching instead of polling for better efficiency
- **`reload=300`** - Increased reload interval to 5 minutes (less disruptive to playback)

## Testing
This fix should resolve the issue reported in IRC where the stream was playing "Underworld - Confusion The Waitress" on repeat.

## Related
Fixes the playlist playback issue discussed on 2025-11-13 in IRC.