### PR TITLE
fix: Replace undefined uri-path with radiance:path

### DIFF
--- a/user-management.lisp
+++ b/user-management.lisp
@@ -175,7 +175,7 @@
    If :api t, returns JSON error (401). Otherwise redirects to login page.
    Auto-detects API routes if not specified."
   (let* ((user-id (session:field "user-id"))
-         (uri (uri-path (radiance:uri *request*)))
+         (uri (radiance:path (radiance:uri *request*)))
          ;; Use explicit flag if provided, otherwise auto-detect from URI
          (is-api-request (if api t (search "/api/" uri))))
     (format t "Authentication check - User ID: ~a, URI: ~a, Is API: ~a~%" 
@@ -202,7 +202,7 @@
    If :api t, returns JSON error (403). Otherwise redirects to login page.
    Auto-detects API routes if not specified."
   (let* ((current-user (get-current-user))
-         (uri (uri-path (radiance:uri *request*)))
+         (uri (radiance:path (radiance:uri *request*)))
          ;; Use explicit flag if provided, otherwise auto-detect from URI
          (is-api-request (if api t (search "/api/" uri))))
     (format t "Current user for role check: ~a~%" (if current-user "FOUND" "NOT FOUND"))


### PR DESCRIPTION
## Problem

My previous commit (2e585e1) introduced a bug by using `uri-path()` which doesn't exist in Radiance. This caused authentication to fail with: The function ASTEROID::URI-PATH is undefined

## Solution

Replace `uri-path` with `radiance:path` - the correct Radiance API function for extracting the path component from a URI object.

## Changes

- Fixed `require-authentication` to use `radiance:path`
- Fixed `require-role` to use `radiance:path`

## Testing

- ✅ Built and ran server successfully
- ✅ Admin login works
- ✅ Authentication redirects work correctly
- ✅ Admin dashboard loads without errors
- ✅ API calls authenticate properly

Apologies for the breakage in the previous patch!