### PR TITLE
Fix styling of audio player on chrome browsers

### DIFF
--- a/static/asteroid.css
+++ b/static/asteroid.css
@@ -270,6 +270,34 @@ body .audio-player{
     text-align: center;
 }
 
+body audio::-webkit-media-controls-panel{
+    background-color: #1a1a1a;
+}
+
+body audio::-webkit-media-controls-current-time-display,
+body audio::-webkit-media-controls-time-remaining-display{
+    color: #fff;
+}
+
+body audio::-webkit-media-controls-enclosure{
+    border-radius: 0;
+}
+
+body audio::-webkit-media-controls-mute-button,
+body audio::-webkit-media-controls-play-button,
+body audio::-webkit-media-controls-volume-slider,
+body audio::-webkit-media-controls-timeline,
+body audio::-webkit-media-controls-toggle-closed-captions-button,
+body audio::-webkit-media-controls-fullscreen-button,
+body audio::-webkit-media-controls-timeline,
+body audio::-webkit-media-controls-overlay-enclosure{
+    -moz-filter: invert(1);
+    -o-filter: invert(1);
+    -webkit-filter: invert(1);
+    -ms-filter: invert(1);
+    filter: invert(1);
+}
+
 body .track-art{
     font-size: 3em;
     margin-right: 20px;

--- a/static/asteroid.lass
+++ b/static/asteroid.lass
@@ -218,6 +218,34 @@
     (.audio-player
      :text-align center)
 
+    ((:and audio |::-webkit-media-controls-panel|)
+     :background-color "#1a1a1a")
+
+    ;; ((:and audio (:or |::-webkit-media-controls-mute-button|
+    ;;                   |::-webkit-media-controls-play-button|
+    ;;                   |::-webkit-media-controls-current-time-display|
+    ;;                   |::-webkit-media-controls-time-remaining-display|
+    ;;                   ))
+    ;;  :height "20px"
+    ;;  :line-height "20px")
+
+    ((:and audio (:or |::-webkit-media-controls-current-time-display|
+                      |::-webkit-media-controls-time-remaining-display|))
+     :color "#fff")
+
+    ((:and audio |::-webkit-media-controls-enclosure|)
+     :border-radius 0)
+
+    ((:and audio (:or |::-webkit-media-controls-mute-button|
+                      |::-webkit-media-controls-play-button|
+                      |::-webkit-media-controls-volume-slider|
+                      |::-webkit-media-controls-timeline|
+                      |::-webkit-media-controls-toggle-closed-captions-button|
+                      |::-webkit-media-controls-fullscreen-button|
+                      |::-webkit-media-controls-timeline|
+                      |::-webkit-media-controls-overlay-enclosure|))
+     :filter "invert(1)")
+
     (.track-art
      :font-size "3em"
      :margin-right "20px"


### PR DESCRIPTION
This PR adds styling for the audio player on chrome browsers. The applied styling mimics the firefox player in what chrome exposes to be configured and produces the following layout:

<img width="1261" height="470" alt="2025-11-15_00-00" src="https://github.com/user-attachments/assets/e11ae8c4-a11e-42c9-8331-3d4abd48c427" />

<img width="1253" height="477" alt="2025-11-15_00-00_1" src="https://github.com/user-attachments/assets/151487ae-e56f-40b5-809f-18e694a6d170" />
