### PR TITLE
Fix live stream panel proportions

### DIFF
--- a/static/asteroid.css
+++ b/static/asteroid.css
@@ -1428,3 +1428,13 @@ body.popout-body .status-mini{
         background-color: #1a2332;
     }
 }
+
+.live-stream-indicator{
+    animation: asteroid-blink 1s steps(5, start) infinite;
+}
+
+@keyframes asteroid-blink{
+    to{
+        visibility: hidden;
+    }
+}

--- a/static/asteroid.lass
+++ b/static/asteroid.lass
@@ -1160,4 +1160,11 @@
                   (audio
                    :opacity 1
                    :background-color #(color-accented-black)))
+
+  ;; Live stream blink animation
+  (.live-stream-indicator
+   :animation "asteroid-blink 1s steps(5, start) infinite")
+
+  (:keyframes asteroid-blink
+              (to :visibility "hidden"))
 ) ;; End of let block

--- a/template/audio-player-frame.ctml
+++ b/template/audio-player-frame.ctml
@@ -7,7 +7,10 @@
 </head>
 <body class="persistent-player-container">
   <div class="persistent-player">
-    <span class="player-label">🟢 LIVE:</span>
+    <span class="player-label">
+      <span class="live-stream-indicator">🟢 </span>
+      LIVE:
+    </span>
     
     <div class="quality-selector">
       <input type="hidden" id="stream-base-url" lquery="(val stream-base-url)">

--- a/template/front-page-content.ctml
+++ b/template/front-page-content.ctml
@@ -35,11 +35,11 @@
 
     <main>
       <div class="live-stream">
-          <h2 style="color: #00ff00; margin: 0;"><span style="font-size: 1rem;">🟢</span> LIVE STREAM</h2>
+          <h2 style="color: #00ff00; margin: 0;"><span class="live-stream-indicator" style="font-size: 1rem;">🟢</span> LIVE STREAM</h2>
         <input type="hidden" id="stream-base-url" lquery="(val stream-base-url)">
         <p><strong class="live-stream-label">Stream URL:</strong> <code id="stream-url" lquery="(text default-stream-url)"></code></p>
         <p><strong class="live-stream-label">Stream Quality:</strong> <span id="stream-format" lquery="(text default-stream-encoding-desc)"></span></p>
-        <p><strong class="live-stream-label">BROADCASTING:</strong> <span id="stream-status" style="">Asteroid music for Hackers.</span></p>
+        <p><strong class="live-stream-label">BROADCASTING:</strong> <span id="stream-status" style="">Asteroid music for Hackers</span></p>
         <p class="frame-enable-message"><em>The live stream player is now in the persistent bar at the bottom of the page</em></p>
       </div>
       

--- a/template/front-page.ctml
+++ b/template/front-page.ctml
@@ -36,7 +36,7 @@
     <main>
       <div class="live-stream">
         <div style="margin-bottom: 20px;">
-          <h2 style="color: #00ff00; margin: 0;"><span style="font-size: 1rem;">🟢</span> LIVE STREAM</h2>
+          <h2 style="color: #00ff00; margin: 0;"><span class="live-stream-indicator" style="font-size: 1rem;">🟢</span> LIVE STREAM</h2>
         </div>
         
         <!-- Stream Quality Selector -->

--- a/template/player-content.ctml
+++ b/template/player-content.ctml
@@ -22,7 +22,10 @@
     
     <!-- Live Stream Section - Note about persistent player -->
     <div class="player-section">
-      <h2 style="color: #00ff00;">🟢 Live Radio Stream</h2>
+      <h2 style="color: #00ff00;">
+        <span class="live-stream-indicator" style="font-size: 1rem;">🟢 </span>
+        Live Radio Stream
+      </h2>
       <p><em>The live stream player is now in the persistent bar at the bottom of the page. It will continue playing as you navigate between pages!</em></p>
     </div>
 

--- a/template/player.ctml
+++ b/template/player.ctml
@@ -22,7 +22,10 @@
     
     <!-- Live Stream Section -->
     <div class="player-section">
-      <h2 style="color: #00ff00;">🟢 Live Radio Stream</h2>
+      <h2 style="color: #00ff00;">
+        <span class="live-stream-indicator" style="font-size: 1rem;">🟢 </span>
+        Live Radio Stream
+      </h2>
       <div class="live-stream">
         <input type="hidden" id="stream-base-url" lquery="(val stream-base-url)">
         <!-- Stream Quality Selector -->

--- a/template/popout-player.ctml
+++ b/template/popout-player.ctml
@@ -41,7 +41,9 @@
         </audio>
 
         <div class="status-mini">
-            <span style="color: #00ff00;">● LIVE</span>
+            <span style="color: #00ff00;">
+              <span class="live-stream-indicator">●</span>
+              LIVE</span>
         </div>
     </div>
 


### PR DESCRIPTION
# Motivation

Since the last UI refactor in the live screen panel, the text proportions were left in an unbalanced size when compared too the other panels in the application.

# Approach

This PR introduces some UI updates and features: 

- Live stream text font was reduced and better adjusted to the remaining panels
- Labels and content now have different colors for better differentiation
- Asteroid moto is now placed as a subtitle of the application
- Background colors in persistent frame and pop out are now more aligned with the theme color palette
- Select component follows the theme colors, align with those already present on the persistent player
- Added a live blink animation to the live stream green circle information
- Updated background colors in the chrome audio widget (Firefox is harder, but I'm on it) 

## Screen recordings

**Firefox**

[firefox-asteroid-2025-11-23_23.18.27.webm](https://github.com/user-attachments/assets/584b646c-cdb2-44de-96b3-04a7736d881c)


**Chrome**

[chrome-asteroid-2025-11-23_23.12.40.webm](https://github.com/user-attachments/assets/931dca97-a5d5-4165-9b6f-10275ab89af4)

# Testing 

Built and browse the application in several browsers to ensure the theme is appropriate 

# Observations 

- I decided to start using LASS variables to standardize color and font usage 
- Moved pop out and persistent player styling to our LASS file 