### PR TITLE
fix: prevent debugger accumulation from vulnerability scanner probes

### DIFF
--- a/asteroid.lisp
+++ b/asteroid.lisp
@@ -977,8 +977,11 @@
     
     ;; Serve regular static file
     (t
-     (serve-file (merge-pathnames (format nil "static/~a" path) 
-                                  (asdf:system-source-directory :asteroid))))))
+     (let ((file-path (merge-pathnames (format nil "static/~a" path)
+                                       (asdf:system-source-directory :asteroid))))
+       (if (probe-file file-path)
+           (serve-file file-path)
+           (error 'radiance:request-not-found))))))
 
 ;; Status check functions
 (defun check-icecast-status ()
@@ -1435,14 +1438,30 @@
 ;; RADIANCE server management functions
 
 (defun start-server (&key (port *server-port*))
-  "Start the Asteroid Radio RADIANCE server"
+  "Start the Asteroid Radio RADIANCE server.
+   Reads ASTEROID_DEBUG from the environment to control Radiance's debugger policy:
+     nil (or unset)       - never invoke debugger (production default)
+     if-swank-connected   - invoke only when Swank/Slynk is connected
+     t                    - always invoke debugger"
   (format t "Starting Asteroid Radio RADIANCE server on port ~a~%"  port)
   (compile-styles)  ; Generate CSS file using LASS
-  
-  ;; Ensure RADIANCE environment is properly set before startup
-  ;; (unless (radiance:environment)
-  ;;   (setf (radiance:environment) "asteroid"))
-  
+
+  ;; Set debugger policy from environment to prevent stray conditions from
+  ;; accumulating debugger sessions (e.g. vulnerability scanners hitting bogus paths)
+  (let ((debug-env (uiop:getenv "ASTEROID_DEBUG")))
+    (setf radiance:*debugger*
+          (cond
+            ((or (null debug-env)
+                 (string-equal debug-env "nil")
+                 (string-equal debug-env ""))
+             nil)
+            ((string-equal debug-env "t")
+             t)
+            ((string-equal debug-env "if-swank-connected")
+             :if-swank-connected)
+            (t nil)))
+    (format t "Debugger policy: ~a~%" radiance:*debugger*))
+
   (radiance:startup)
   
   ;; Start listener statistics polling

--- a/conditions.lisp
+++ b/conditions.lisp
@@ -202,3 +202,27 @@
   (error 'authorization-error
          :message message
          :required-role required-role))
+
+;;; Override Radiance's default render-error-page to return proper HTTP
+;;; status codes instead of a blanket 500 for conditions like
+;;; request-not-found and file-to-serve-does-not-exist. This prevents
+;;; vulnerability scanners from generating misleading 500 responses and
+;;; gives us control over error presentation.
+(defun radiance:render-error-page (condition)
+  (cond
+    ((typep condition 'radiance:request-not-found)
+     (setf (radiance:return-code radiance:*response*) 404)
+     (setf (radiance:content-type radiance:*response*) "text/plain")
+     "Not Found")
+    ((typep condition 'radiance:file-to-serve-does-not-exist)
+     (setf (radiance:return-code radiance:*response*) 404)
+     (setf (radiance:content-type radiance:*response*) "text/plain")
+     "Not Found")
+    ((typep condition 'radiance:request-denied)
+     (setf (radiance:return-code radiance:*response*) 403)
+     (setf (radiance:content-type radiance:*response*) "text/plain")
+     "Forbidden")
+    (t
+     (setf (radiance:return-code radiance:*response*) 500)
+     (setf (radiance:content-type radiance:*response*) "text/plain")
+     "Internal Server Error")))


### PR DESCRIPTION
## Summary

External vulnerability scanners probing for common exploits (e.g. `/wp-login.php`, `/.env`, `/admin/config.php`) generate requests that hit nonexistent paths. In the current code, these trigger Radiance conditions (`FILE-TO-SERVE-DOES-NOT-EXIST`, `REQUEST-NOT-FOUND`) that drop into the SBCL debugger when Swank/Slynk is connected. Each probe opens a debugger session on its own thread; when enough accumulate, the runtime locks up.

## Changes

Three defence-in-depth fixes across two files:

- **Static file handler** (`asteroid.lisp`): `probe-file` before calling `serve-file`, so `FILE-TO-SERVE-DOES-NOT-EXIST` is never signalled — signals `REQUEST-NOT-FOUND` instead, which Radiance handles more gracefully
- **Debugger policy** (`asteroid.lisp`): `start-server` now reads `ASTEROID_DEBUG` from the environment (set in `docker/environment.sh`) to control `radiance:*debugger*` — defaults to `nil` (never invoke debugger) in production
- **Error page override** (`conditions.lisp`): Overrides `radiance:render-error-page` to return proper HTTP status codes (404, 403, 500) instead of Radiance's default blanket 500 for all conditions

## Code path

1. Scanner hits e.g. `/static/../../.env`
2. Asteroid's catch-all static route matches
3. **Before**: `serve-file` called on nonexistent path → signals `FILE-TO-SERVE-DOES-NOT-EXIST` → `handle-condition` → `maybe-invoke-debugger` → debugger session opened per thread
4. **After**: `probe-file` returns nil → signals `REQUEST-NOT-FOUND` → `handle-condition` → `*debugger*` is nil → `abort` restart → `render-error-page` returns 404

## Test plan

- [x] Start server with `ASTEROID_DEBUG=nil`, confirm no debugger on bogus requests
- [x] `curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/static/nonexistent` returns 404
- [x] `curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/wp-login.php` returns 404
- [x] Start server with `ASTEROID_DEBUG=t`, confirm debugger fires for real errors
- [x] Verify normal static file serving still works

🅯 Brian O'Reilly <fade@deepsky.com>, 2026