### PR TITLE
fix: replace r-simple-rate sliding-window with fixed-window rate limiter

### DIFF
--- a/frontend-partials.lisp
+++ b/frontend-partials.lisp
@@ -93,7 +93,7 @@
               (:track-id . ,(find-track-by-title title))
               (:favorite-count . ,(or (get-track-favorite-count title) 1))))))))
 
-(define-api-with-limit asteroid/partial/now-playing (&optional mount) (:limit 10 :timeout 1)
+(define-api-with-limit asteroid/partial/now-playing (&optional mount) (:limit 120 :timeout 60)
   "Get Partial HTML with live status from Icecast server.
    Optional MOUNT parameter specifies which stream to get metadata from.
    Always polls both streams to keep recently played lists updated."
@@ -123,7 +123,7 @@
              :connection-error t
              :stats nil))))))
 
-(define-api-with-limit asteroid/partial/now-playing-inline (&optional mount) (:limit 10 :timeout 1)
+(define-api-with-limit asteroid/partial/now-playing-inline (&optional mount) (:limit 120 :timeout 60)
   "Get inline text with now playing info (for admin dashboard and widgets).
    Optional MOUNT parameter specifies which stream to get metadata from."
   (with-error-handling
@@ -137,7 +137,7 @@
             (setf (header "Content-Type") "text/plain")
             "Stream Offline")))))
 
-(define-api-with-limit asteroid/partial/now-playing-json (&optional mount) (:limit 10 :timeout 1)
+(define-api-with-limit asteroid/partial/now-playing-json (&optional mount) (:limit 120 :timeout 60)
   "Get JSON with now playing info including track ID for favorites.
    Optional MOUNT parameter specifies which stream to get metadata from."
   ;; Register web listener for geo stats (keeps listener active during playback)

--- a/limiter.lisp
+++ b/limiter.lisp
@@ -1,4 +1,10 @@
 ;;;; limiter.lisp - Rate limiter definitions for the application
+;;;;
+;;;; Replaces r-simple-rate's with-limitation with a fixed-window
+;;;; implementation.  The upstream tax-rate updates the timestamp on
+;;;; EVERY request, preventing the window from ever resetting while
+;;;; polling is active.  Our define-*-with-limit macros bypass
+;;;; rate:with-limitation entirely and call fixed-window-check instead.
 
 (in-package :asteroid)
 
@@ -14,6 +20,50 @@
           (l:info :rate-limiter "Cleaned up ~a corrupted rate limit entries" deleted)))
     (error (e)
       (l:warn :rate-limiter "Failed to cleanup rate limits: ~a" e))))
+
+;;; --- Fixed-window rate limiter ---
+;;;
+;;; r-simple-rate has a sliding-window bug: tax-rate updates the timestamp
+;;; on every request, so the window never resets while polling is active.
+;;; Rather than monkey-patching (Radiance may reload the module and clobber
+;;; our overrides), we implement our own fixed-window logic directly.
+
+(defun fixed-window-check (limit-name max-requests timeout-seconds)
+  "Check and tax a fixed-window rate limit.  Returns T if the request
+   is allowed, or (VALUES NIL seconds-remaining) if rate-limited.
+   LIMIT-NAME is a string key, MAX-REQUESTS and TIMEOUT-SECONDS are integers.
+   Uses the SIMPLE-RATE/TRACKING table for storage."
+  (let* ((ip (remote *request*))
+         (tracking (dm:get-one 'simple-rate::tracking
+                               (db:query (:and (:= 'limit limit-name)
+                                               (:= 'ip ip)))))
+         (now (get-universal-time)))
+    (cond
+      ;; Existing entry
+      (tracking
+       (let ((window-end (+ (dm:field tracking "time") timeout-seconds)))
+         (when (<= window-end now)
+           ;; Window expired - reset counter and start new window
+           (setf (dm:field tracking "amount") max-requests)
+           (setf (dm:field tracking "time") now)
+           (setf window-end (+ now timeout-seconds)))
+         ;; Check budget
+         (if (<= (dm:field tracking "amount") 0)
+             ;; Exhausted - report time remaining
+             (values nil (- window-end now))
+             ;; Allowed - decrement and save
+             (progn
+               (decf (dm:field tracking "amount"))
+               (dm:save tracking)
+               t))))
+      ;; First request ever from this IP for this limit
+      (t
+       (db:insert 'simple-rate::tracking
+                  `((limit . ,limit-name)
+                    (time . ,now)
+                    (amount . ,(1- max-requests))
+                    (ip . ,ip)))
+       t))))
 
 (define-trigger db:connected ()
   "Clean up any corrupted rate limit entries on startup"
@@ -43,31 +93,31 @@
 
 
 (defmacro define-page-with-limit (name uri options &body body)
-  "Rate limit for a page route. Defaults to 30 requests per minute."
+  "Rate limit for a page route. Defaults to 30 requests per minute.
+   Uses fixed-window rate limiting (not r-simple-rate's sliding window)."
   (multiple-value-bind (limit timeout group rest) (extract-limit-options options)
     (let* ((limit-name (string-upcase (format nil "~a-route-limit" (or group name))))
-           (limit-sym (intern limit-name))
            (limit (or limit 30))
            (timeout (or timeout 60)))
-      `(eval-when (:compile-toplevel :load-toplevel :execute)
-         (rate:define-limit ,limit-sym (time-left :limit ,limit :timeout ,timeout)
-           ;; (format t "Route limit '~a' hit. Wait ~a seconds and retry.~%" ,(string name) time-left)
-           (render-rate-limit-error-page))
-         (define-page ,name ,uri ,rest
-           (rate:with-limitation (,limit-sym)
-             ,@body))))))
+      `(define-page ,name ,uri ,rest
+         (multiple-value-bind (allowed time-left)
+             (fixed-window-check ,limit-name ,limit ,timeout)
+           (declare (ignorable time-left))
+           (if allowed
+               (progn ,@body)
+               (render-rate-limit-error-page)))))))
 
 (defmacro define-api-with-limit (name args options &body body)
-  "Rate limit for api routes. Defaults to 60 requests per minute."
+  "Rate limit for api routes. Defaults to 60 requests per minute.
+   Uses fixed-window rate limiting (not r-simple-rate's sliding window)."
   (multiple-value-bind (limit timeout group rest) (extract-limit-options options)
     (let* ((limit-name (string-upcase (format nil "~a-api-limit" (or group name))))
-           (limit-sym (intern limit-name))
            (limit (or limit 60))
            (timeout (or timeout 60)))
-      `(eval-when (:compile-toplevel :load-toplevel :execute)
-         (rate:define-limit ,limit-sym (time-left :limit ,limit :timeout ,timeout)
-           ;; (format t "API Rate limit '~a' hit. Wait ~a seconds and retry.~%" ,(string name) time-left)
-           (api-limit-error-output))
-         (define-api ,name ,args ,rest
-           (rate:with-limitation (,limit-sym)
-             ,@body))))))
+      `(define-api ,name ,args ,rest
+         (multiple-value-bind (allowed time-left)
+             (fixed-window-check ,limit-name ,limit ,timeout)
+           (declare (ignorable time-left))
+           (if allowed
+               (progn ,@body)
+               (api-limit-error-output)))))))

--- a/parenscript/front-page.lisp
+++ b/parenscript/front-page.lisp
@@ -776,7 +776,7 @@
                                  (setf (ps:@ curated-option text-content) (+ "🎧 " current-channel-name)))))))))))
            (catch (lambda (error)
                     (ps:chain console (log "Could not fetch channel name:" error))))))
-        10000))  ;; Poll every 10 seconds
+        15000))  ;; Poll every 15 seconds
     
     ;; Listen for messages from popout window
      (ps:chain window


### PR DESCRIPTION
## Problem

The frontend polls several now-playing API endpoints every few seconds to keep the UI current. Under normal use with even a handful of listeners, these endpoints return 429 (Too Many Requests) errors constantly. The errors flood the browser console and cause visible UI stalls where now-playing information stops updating until the rate limit window expires.

Previous attempts to fix this by increasing the `:limit` and `:timeout` values on the endpoint definitions did not work. The rate limits appeared to reset on every server restart, and under sustained polling the counters would go negative and never recover.

## Root Cause

The rate limiting is provided by `r-simple-rate`, which uses a sliding-window algorithm in its `tax-rate` function. The bug is that `tax-rate` updates the tracking timestamp on **every** request, not just when the window resets. This means that as long as a client is actively polling (which is always the in our case), the window start time keeps sliding forward and the counter never resets to its full budget. The window effectively never expires.

Additionally, when the counter goes below zero (which happens easily under this bug), the reset condition in `tax-rate` checks `(>= amount 0)` before resetting. A negative amount never satisfies that condition, so the entry stays corrupted permanently until the database is manually cleared.

This combination means:
1. Normal polling exhausts the rate limit budget quickly
2. The sliding timestamp prevents the window from ever truly expiring
3. Once the counter goes negative, it is permanently stuck
4. Server restarts do not fix the problem because the corrupted tracking entries persist in the database

## Solution

### 1. Fixed-window rate limiter (`limiter.lisp`)

Rather than monkey-patching `r-simple-rate` (which Radiance may reload and overwrite), we bypass `rate:with-limitation` entirely and implement a straightforward fixed-window rate limiter called `fixed-window-check`.

The key difference: the window start timestamp is only updated when the window has actually expired. During the window, only the counter is decremented. This guarantees that the window will reset after the configured timeout, regardless of how many requests arrive during it.

The `define-page-with-limit` and `define-api-with-limit` macros now call `fixed-window-check` directly instead of wrapping the body in `rate:with-limitation`. The existing `cleanup-corrupted-rate-limits` trigger still runs on startup to clear any negative-counter entries left over from the old implementation.

The function reuses the existing `simple-rate::tracking` database table for storage, so no schema changes are needed.

### 2. Rate limit increases for now-playing endpoints (`frontend-partials.lisp`)

The three now-playing endpoints were configured with extremely tight limits:
- `asteroid/partial/now-playing`: 10 requests per 1 second
- `asteroid/partial/now-playing-inline`: 10 requests per 1 second
- `asteroid/partial/now-playing-json`: 10 requests per 1 second

These have been changed to **120 requests per 60 seconds** (2 per second sustained). This comfortably accommodates the frontend polling intervals (which fire every few seconds per open tab) while still providing protection against actual abuse.

### 3. Polling interval adjustment (`parenscript/front-page.lisp`)

The channel-name polling interval has been increased from 10 seconds to 15 seconds. This reduces the baseline request rate from the frontend without any noticeable impact on UX, since channel name changes are infrequent.

## Files Changed

- **`limiter.lisp`** - Added `fixed-window-check` function; rewrote `define-page-with-limit` and `define-api-with-limit` macros to use it instead of `rate:with-limitation`
- **`frontend-partials.lisp`** - Changed rate limits on three now-playing endpoints from `(:limit 10 :timeout 1)` to `(:limit 120 :timeout 60)`
- **`parenscript/front-page.lisp`** - Changed channel-name polling interval from 10s to 15s

## Testing

These changes were previously validated on the `cl-streamer-standalone` branch where they eliminated all 429 errors under normal operation. The fixed-window implementation has been running without issues there.