### PR TITLE
test: add asteroid-tests system covering the env-driven URL helpers

### DIFF
--- a/asteroid-tests.asd
+++ b/asteroid-tests.asd
@@ -1,0 +1,18 @@
+;; -*-lisp-*-
+;;;; asteroid-tests.asd
+
+(asdf:defsystem #:asteroid-tests
+  :description "Unit tests for asteroid. Kept as a separate system so the test
+framework dependency doesn't bloat the production binary."
+  :author "Brian O'Reilly <fade@deepsky.com>"
+  :license "GNU AFFERO GENERAL PUBLIC LICENSE V.3"
+  :serial t
+  :version "1.0.0"
+  :depends-on (:asteroid
+               :parachute)
+  :pathname "tests/"
+  :components ((:file "package")
+               (:file "url-helpers")
+               (:file "stream-config"))
+  :perform (asdf:test-op (op c)
+             (uiop:symbol-call :parachute :test :asteroid-tests)))

--- a/docs/TESTING.org
+++ b/docs/TESTING.org
@@ -4,13 +4,68 @@
 
 * Overview
 
-This document describes the automated testing system for Asteroid Radio.
+Asteroid Radio has two test layers:
+
+1. *Unit tests* — In-image CL tests run via ASDF + parachute. Cover pure
+   helpers and tight side-effecting functions in isolation. Fast (<1s).
+   Live in =tests/= and are described in [[*Unit Tests][Unit Tests]] below.
+2. *Integration tests* — The =test-server.sh= shell script. Drives the
+   running server with curl, validates that endpoints respond. Described
+   in [[*Integration Tests][Integration Tests]] below.
+
+The two layers are complementary: unit tests catch logic regressions
+before the binary is even built; the integration script catches wiring
+regressions that only surface against a live server.
 
 #+BEGIN_QUOTE
 *Note on Package Managers*: Examples use =apt= (Debian/Ubuntu). Replace with your distribution's package manager (=dnf=, =pacman=, =zypper=, =apk=, etc.).
 #+END_QUOTE
 
-* Test Script
+* Unit Tests
+
+The =asteroid-tests= ASDF system covers the pure CL helpers in asteroid:
+URL parsing, stream-URL derivation, the startup scheme-mismatch
+detector. Tests live in =tests/= and use [[https://shinmera.github.io/parachute/][parachute]].
+
+** Running
+
+From a Lisp REPL with quicklisp + the asteroid checkout on the
+=*central-registry*=:
+
+#+BEGIN_SRC lisp
+;; first time only — parachute isn't an asteroid dep
+(ql:quickload :parachute)
+
+;; Run the suite
+(asdf:test-system :asteroid-tests)
+
+;; Or interactively, with parachute's reporter
+(parachute:test :asteroid-tests)
+#+END_SRC
+
+The suite is fast; the full set runs in well under a second.
+
+** Layout
+
+| File | Covers |
+|---+---|
+| =tests/package.lisp=        | =asteroid-tests= package; =with-env-vars= helper for mocking env vars |
+| =tests/url-helpers.lisp=    | =url-scheme=, =derive-stream-url-from-station= |
+| =tests/stream-config.lisp=  | =check-stream-url-scheme= behavior across env-var combinations |
+
+** Adding tests
+
+New CL tests should:
+
+- Live in =tests/= and be added as a component of =asteroid-tests.asd=
+- Use =parachute:define-test= for the test form
+- Use =asteroid-tests:with-env-vars= when the function-under-test reads env
+- Reference asteroid internals via =asteroid::= (double-colon — most are not exported)
+
+The framework is SBCL-only (=sb-posix:setenv= is used to mock env vars).
+Asteroid itself is SBCL-only in production, so this is consistent.
+
+* Integration Tests
 
 The =test-server.sh= script provides comprehensive testing of all server endpoints and functionality.
 

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -1,0 +1,43 @@
+;;;; tests/package.lisp
+
+(defpackage #:asteroid-tests
+  (:use #:cl #:parachute)
+  (:export #:with-env-vars))
+
+(in-package :asteroid-tests)
+
+(defun call-with-env-vars (bindings thunk)
+  "Run THUNK with environment variables set per BINDINGS, then restore.
+
+BINDINGS is an alist of (\"NAME\" . VALUE-OR-NIL).
+- VALUE a string -> setenv NAME=VALUE
+- VALUE nil      -> unsetenv NAME
+
+Uses sb-posix directly because the asteroid binary is SBCL-only and the
+UIOP version pinned in this project does not export portable setenv.
+Pre-existing values are saved as :unset or as their string value and
+restored after THUNK regardless of how it exits."
+  #-sbcl (error "asteroid-tests requires SBCL for env-var manipulation")
+  (let ((saved (mapcar (lambda (b)
+                         (cons (car b) (or (uiop:getenvp (car b)) :unset)))
+                       bindings)))
+    (unwind-protect
+         (progn
+           (dolist (b bindings)
+             (cond
+               ((cdr b) (sb-posix:setenv (car b) (cdr b) 1))
+               (t       (sb-posix:unsetenv (car b)))))
+           (funcall thunk))
+      (dolist (s saved)
+        (cond
+          ((eq (cdr s) :unset) (sb-posix:unsetenv (car s)))
+          (t                   (sb-posix:setenv (car s) (cdr s) 1)))))))
+
+(defmacro with-env-vars (bindings &body body)
+  "Execute BODY with the given environment-variable BINDINGS in effect.
+
+BINDINGS is a list of (NAME VALUE-OR-NIL), VALUE-OR-NIL nil meaning unset.
+Saves and restores the pre-call env state."
+  `(call-with-env-vars
+    (list ,@(mapcar (lambda (b) `(cons ,(first b) ,(second b))) bindings))
+    (lambda () ,@body)))

--- a/tests/stream-config.lisp
+++ b/tests/stream-config.lisp
@@ -1,0 +1,71 @@
+;;;; tests/stream-config.lisp
+;;;;
+;;;; Behavioral tests for the env-var-driven stream-URL configuration logic.
+;;;; Each test sets the relevant env vars via WITH-ENV-VARS, captures
+;;;; *standard-output*, and asserts on the produced banner text.
+
+(in-package :asteroid-tests)
+
+(defun run-check-stream-url-scheme-with-env (bindings)
+  "Helper: run asteroid::check-stream-url-scheme with the given env BINDINGS
+   and return the captured *standard-output* as a string."
+  (call-with-env-vars bindings
+    (lambda ()
+      (with-output-to-string (out)
+        (let ((*standard-output* out))
+          (asteroid::check-stream-url-scheme))))))
+
+(define-test check-stream-url-scheme/match
+  "When STATION_URL and ASTEROID_STREAM_URL share a scheme, log a one-line
+   confirmation and no warning."
+  (let ((out (run-check-stream-url-scheme-with-env
+              '(("STATION_URL" . "https://asteroid.radio")
+                ("ASTEROID_STREAM_URL" . "https://ice.asteroid.radio")))))
+    (true  (search "schemes match" out))
+    (false (search "WARNING" out))))
+
+(define-test check-stream-url-scheme/mismatch
+  "When schemes disagree, emit a prominent warning that names both URLs."
+  (let ((out (run-check-stream-url-scheme-with-env
+              '(("STATION_URL" . "https://asteroid.radio")
+                ("ASTEROID_STREAM_URL" . "http://ice.asteroid.radio")))))
+    (true (search "WARNING"          out))
+    (true (search "scheme mismatch"  out))
+    (true (search "https://asteroid.radio"     out))
+    (true (search "http://ice.asteroid.radio"  out))
+    (true (search "mixed-content"    out))))
+
+(define-test check-stream-url-scheme/either-unset
+  "When STATION_URL or ASTEROID_STREAM_URL is unset, no-op (no output)."
+  ;; STATION_URL unset
+  (let ((out (run-check-stream-url-scheme-with-env
+              '(("STATION_URL" . nil)
+                ("ASTEROID_STREAM_URL" . "http://ice.asteroid.radio")))))
+    (false (search "WARNING"        out))
+    (false (search "schemes match"  out)))
+  ;; ASTEROID_STREAM_URL unset
+  (let ((out (run-check-stream-url-scheme-with-env
+              '(("STATION_URL" . "https://asteroid.radio")
+                ("ASTEROID_STREAM_URL" . nil)))))
+    (false (search "WARNING"        out))
+    (false (search "schemes match"  out)))
+  ;; both unset
+  (let ((out (run-check-stream-url-scheme-with-env
+              '(("STATION_URL" . nil)
+                ("ASTEROID_STREAM_URL" . nil)))))
+    (is equal "" out)))
+
+(define-test check-stream-url-scheme/malformed
+  "When either env var lacks ://, warn but don't crash."
+  ;; malformed STATION_URL
+  (let ((out (run-check-stream-url-scheme-with-env
+              '(("STATION_URL" . "asteroid.radio")
+                ("ASTEROID_STREAM_URL" . "https://ice.asteroid.radio")))))
+    (true (search "WARNING"   out))
+    (true (search "malformed" out)))
+  ;; malformed ASTEROID_STREAM_URL
+  (let ((out (run-check-stream-url-scheme-with-env
+              '(("STATION_URL" . "https://asteroid.radio")
+                ("ASTEROID_STREAM_URL" . "ice.asteroid.radio")))))
+    (true (search "WARNING"   out))
+    (true (search "malformed" out))))

--- a/tests/url-helpers.lisp
+++ b/tests/url-helpers.lisp
@@ -1,0 +1,39 @@
+;;;; tests/url-helpers.lisp
+;;;;
+;;;; Unit tests for the pure URL-string helpers in asteroid.lisp.
+
+(in-package :asteroid-tests)
+
+(define-test url-scheme
+  "asteroid::url-scheme extracts the scheme of a URL string."
+  ;; happy path
+  (is equal "https" (asteroid::url-scheme "https://asteroid.radio"))
+  (is equal "http"  (asteroid::url-scheme "http://localhost:8080"))
+  (is equal "https" (asteroid::url-scheme "https://x:443/path"))
+  ;; scheme normalized to lowercase
+  (is equal "https" (asteroid::url-scheme "HTTPS://Example.com"))
+  (is equal "http"  (asteroid::url-scheme "HtTp://x"))
+  ;; nil / empty / missing separator -> nil
+  (false (asteroid::url-scheme nil))
+  (false (asteroid::url-scheme ""))
+  (false (asteroid::url-scheme "asteroid.radio"))
+  (false (asteroid::url-scheme "://no-scheme")))
+
+(define-test derive-stream-url-from-station
+  "asteroid::derive-stream-url-from-station prepends ice. to the host portion."
+  ;; happy path
+  (is equal "https://ice.asteroid.radio"
+      (asteroid::derive-stream-url-from-station "https://asteroid.radio"))
+  ;; port is preserved
+  (is equal "https://ice.asteroid.radio:8443"
+      (asteroid::derive-stream-url-from-station "https://asteroid.radio:8443"))
+  ;; path is preserved
+  (is equal "https://ice.asteroid.radio/x/y"
+      (asteroid::derive-stream-url-from-station "https://asteroid.radio/x/y"))
+  ;; scheme is preserved (http -> http)
+  (is equal "http://ice.localhost:8080"
+      (asteroid::derive-stream-url-from-station "http://localhost:8080"))
+  ;; malformed / nil / empty -> nil
+  (false (asteroid::derive-stream-url-from-station nil))
+  (false (asteroid::derive-stream-url-from-station ""))
+  (false (asteroid::derive-stream-url-from-station "asteroid.radio")))


### PR DESCRIPTION
Sets up the first in-image unit test layer for asteroid. Tests live in
a separate ASDF system (asteroid-tests) so the test framework dep stays
out of the production binary. Parachute was picked because it's small,
modern, and authored by shinmera.

Initial coverage (32 assertions across 6 test groups):

- url-scheme: scheme extraction with lowercase normalization, nil/empty/
  malformed-input tolerance.
- derive-stream-url-from-station: prepends 'ice.' to host while preserving
  scheme, port, and path; returns nil on malformed input.
- check-stream-url-scheme: env-var-driven startup banner. Verifies the
  match path emits a one-line confirmation, the mismatch path emits a
  prominent warning naming both URLs and the mixed-content explanation,
  the either-unset path is silent, and the malformed-URL path warns
  instead of crashing.

The env-mocking helper uses sb-posix:setenv/unsetenv (uiop has no portable
setenv in the version pinned here, and asteroid is SBCL-only anyway).

Verified locally: (asdf:test-system :asteroid-tests) -> 32 passed / 0
failed in <0.3s.

docs/TESTING.org reorganized to introduce the new unit-test layer as
a top-level section alongside the existing integration shell script;
existing test-server.sh documentation is now under "Integration Tests".

Coverage gaps acknowledged but out of scope for this PR:
- The Radiance response-header function (set-no-cache-headers, #110)
  requires a live request context to exercise — integration testing
  rather than unit testing.
- The cron scheduler register/deregister functions mutate cl-cron
  global state and want their own setup/teardown harness.

🄯 Brian O'Reilly <fade@deepsky.com>, 2026
