### PR TITLE
chore: add AGPL-3.0-or-later SPDX identifiers to sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 *.FASL
 *.fasl
+*.ufasl
+*.cfasl
+*.x86f
 *.lisp-temp
+.asdf-cache/
 *.dfsl
 *.pfsl
 *.d64fsl
@@ -17,6 +21,8 @@
 *.wx32fsl
 /slime.lisp
 asteroid
+bin/
+*.pid
 *.wma
 
 # Docker music directory - keep folder but ignore music files
@@ -65,4 +71,3 @@ playlists/stream-queue.m3u
 /radiance-bootstrap.lisp
 /test-postgres-db.lisp
 /userdump.csv
-.envrc

--- a/app-utils.lisp
+++ b/app-utils.lisp
@@ -1,4 +1,5 @@
 ;; -*-lisp-*-
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 
 (defpackage :asteroid.app-utils
   (:use :cl)

--- a/asteroid-tests.asd
+++ b/asteroid-tests.asd
@@ -1,11 +1,12 @@
 ;; -*-lisp-*-
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; asteroid-tests.asd
 
 (asdf:defsystem #:asteroid-tests
   :description "Unit tests for asteroid. Kept as a separate system so the test
 framework dependency doesn't bloat the production binary."
   :author "Brian O'Reilly <fade@deepsky.com>"
-  :license "GNU AFFERO GENERAL PUBLIC LICENSE V.3"
+  :license "AGPL-3.0-or-later"
   :serial t
   :version "1.0.0"
   :depends-on (:asteroid

--- a/asteroid.asd
+++ b/asteroid.asd
@@ -1,10 +1,11 @@
 ;; -*-lisp-*-
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; asteroid.asd
 
 (asdf:defsystem #:asteroid
   :description "A radio station to stream Asteroid Music"
   :author "Brian O'Reilly <fade@deepsky.com>"
-  :license "GNU AFFERO GENERAL PUBLIC LICENSE V.3"
+  :license "AGPL-3.0-or-later"
   :serial t
   :version "1.0.0"
   :defsystem-depends-on (:radiance)

--- a/asteroid.lisp
+++ b/asteroid.lisp
@@ -1,4 +1,5 @@
 ;; -*-lisp-*-
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;; (defpackage :asteroid
 ;;   (:use :cl :radiance)
 ;;   (:use :asteroid.app-utils)

--- a/auth-routes.lisp
+++ b/auth-routes.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; auth-routes.lisp - Authentication Routes for Asteroid Radio
 ;;;; Web routes for user authentication, registration, and management
 

--- a/build-asteroid.lisp
+++ b/build-asteroid.lisp
@@ -1,4 +1,5 @@
 ;; -*-lisp-*-
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 
 (unless *load-pathname*
   (error "Please LOAD this file."))

--- a/conditions.lisp
+++ b/conditions.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; conditions.lisp - Custom error conditions for Asteroid Radio
 ;;;; Provides a hierarchy of error conditions for better error handling and debugging
 

--- a/config/radiance-postgres.lisp
+++ b/config/radiance-postgres.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; Radiance PostgreSQL Configuration for Asteroid Radio
 ;;;; This file configures Radiance to use PostgreSQL instead of the default database
 

--- a/database.lisp
+++ b/database.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 (in-package :asteroid)
 
 ;; Database connection parameters for direct postmodern queries

--- a/frontend-partials.lisp
+++ b/frontend-partials.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 (in-package :asteroid)
 
 (defun find-track-by-title (title)

--- a/limiter.lisp
+++ b/limiter.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; limiter.lisp - Rate limiter definitions for the application
 ;;;;
 ;;;; Replaces r-simple-rate's with-limitation with a fixed-window

--- a/listener-stats.lisp
+++ b/listener-stats.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; listener-stats.lisp - Listener Statistics Collection Service
 ;;;; Polls Icecast for listener data and stores with GDPR compliance
 

--- a/module.lisp
+++ b/module.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 (in-package #:rad-user)
 
 (define-module #:asteroid

--- a/parenscript-utils.lisp
+++ b/parenscript-utils.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; parenscript-utils.lisp
 ;;;; Utilities for generating JavaScript from ParenScript
 

--- a/parenscript/admin.lisp
+++ b/parenscript/admin.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; admin.lisp - ParenScript version of admin.js
 ;;;; Admin Dashboard functionality including track management, queue controls, and player
 

--- a/parenscript/auth-ui.lisp
+++ b/parenscript/auth-ui.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; auth-ui.lisp - ParenScript version of auth-ui.js
 ;;;; Handle authentication UI state across all pages
 

--- a/parenscript/frameset-utils.lisp
+++ b/parenscript/frameset-utils.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; frameset-utils.lisp - ParenScript for frameset utilities
 ;;;; Frame-busting and other frameset-related functionality
 

--- a/parenscript/front-page.lisp
+++ b/parenscript/front-page.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; front-page.lisp - ParenScript version of front-page.js
 ;;;; Stream quality, now playing, pop-out player, frameset mode
 

--- a/parenscript/parenscript-utils.lisp
+++ b/parenscript/parenscript-utils.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; parenscript-utils.lisp - ParenScript utility functions
 
 (in-package #:asteroid)

--- a/parenscript/player.lisp
+++ b/parenscript/player.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; player.lisp - ParenScript version of player.js
 ;;;; Web Player functionality including audio playback, playlists, queue management, and live streaming
 

--- a/parenscript/profile.lisp
+++ b/parenscript/profile.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; profile.lisp - ParenScript version of profile.js
 ;;;; User profile page with listening stats and history
 

--- a/parenscript/recently-played.lisp
+++ b/parenscript/recently-played.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; recently-played.lisp - ParenScript version of recently-played.js
 ;;;; Recently Played Tracks functionality
 

--- a/parenscript/spectrum-analyzer.lisp
+++ b/parenscript/spectrum-analyzer.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 (in-package #:asteroid)
 
 ;;; Spectrum Analyzer - Parenscript Implementation

--- a/parenscript/stream-player.lisp
+++ b/parenscript/stream-player.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; stream-player.lisp - ParenScript for persistent stream player
 ;;;; Handles audio-player-frame and popout-player stream reconnect logic
 

--- a/parenscript/users.lisp
+++ b/parenscript/users.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; users.lisp - ParenScript version of users.js
 ;;;; User management page for admins
 

--- a/playlist-management.lisp
+++ b/playlist-management.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; playlist-management.lisp - Playlist Management for Asteroid Radio
 ;;;; Database operations and functions for user playlists
 

--- a/playlist-scheduler.lisp
+++ b/playlist-scheduler.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; playlist-scheduler.lisp - Automatic Playlist Scheduling for Asteroid Radio
 ;;;; Uses cl-cron to load time-based playlists at scheduled times
 

--- a/setup-environment.lisp
+++ b/setup-environment.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; Setup script for Asteroid Radio Radiance environment
 ;;;; This creates the necessary symbolic links for the custom environment
 

--- a/stream-control.lisp
+++ b/stream-control.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; stream-control.lisp - Stream Queue and Playlist Control for Asteroid Radio
 ;;;; Manages the main broadcast stream queue and generates M3U playlists for Liquidsoap
 

--- a/stream-media.lisp
+++ b/stream-media.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 (in-package :asteroid)
 
 ;; Music library scanning functions

--- a/template-utils.lisp
+++ b/template-utils.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; template-utils.lisp - CLIP Template Processing Utilities
 ;;;; Proper CLIP-based template rendering using keyword arguments
 

--- a/test-parenscript.lisp
+++ b/test-parenscript.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; test-parenscript.lisp - Test ParenScript compilation
 
 (ql:quickload :parenscript)

--- a/test-ps-compile.lisp
+++ b/test-ps-compile.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; test-ps-compile.lisp - Test ParenScript compilation for auth-ui
 
 (load "~/quicklisp/setup.lisp")

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; tests/package.lisp
 
 (defpackage #:asteroid-tests

--- a/tests/scheduler.lisp
+++ b/tests/scheduler.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; tests/scheduler.lisp
 ;;;;
 ;;;; Unit tests for playlist-scheduler.lisp's cron-job management — the

--- a/tests/stream-config.lisp
+++ b/tests/stream-config.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; tests/stream-config.lisp
 ;;;;
 ;;;; Behavioral tests for the env-var-driven stream-URL configuration logic.

--- a/tests/url-helpers.lisp
+++ b/tests/url-helpers.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; tests/url-helpers.lisp
 ;;;;
 ;;;; Unit tests for the pure URL-string helpers in asteroid.lisp.

--- a/track-requests.lisp
+++ b/track-requests.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 (in-package #:asteroid)
 
 ;;; ==========================================================================

--- a/user-management.lisp
+++ b/user-management.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; user-management.lisp - User Management System for Asteroid Radio
 ;;;; Core user management functionality and database operations
 

--- a/user-playlists.lisp
+++ b/user-playlists.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 (in-package :asteroid)
 
 ;;; ==========================================================================

--- a/user-profile.lisp
+++ b/user-profile.lisp
@@ -1,3 +1,4 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 ;;;; user-profile.lisp - User profile features: favorites, listening history
 ;;;; Part of Asteroid Radio
 

--- a/users.lisp
+++ b/users.lisp
@@ -1,1 +1,2 @@
+;;;; SPDX-License-Identifier: AGPL-3.0-or-later
 (in-package :asteroid)


### PR DESCRIPTION
## What changed

Every hand-written Lisp source file and both system definitions now carry an
SPDX license identifier. Three serialized-state files are excepted, listed
below. The `:license` field in `asteroid.asd` and `asteroid-tests.asd` changes
from the prose string "GNU AFFERO GENERAL PUBLIC LICENSE V.3" to
`AGPL-3.0-or-later`.

A second, independent commit extends the ignore list to cover fasl variants
produced by CMUCL and LispWorks, plus the binary output directory, pid files
and the ASDF cache, and drops `.envrc`, which is ignored locally instead.

## Why

The project ships under the GNU AGPL v3, but no source file said so. The terms
were discoverable only by finding LICENSE at the repository root, which leaves
any file that travels on its own with no stated license. A per-file identifier
lets license scanners, packagers and downstream consumers determine the terms of
each file directly, and a machine-readable `:license` value can be matched by
tooling in a way the prose name could not.

The ignore change is smaller: compiling off SBCL left build output showing up as
untracked files.

## Reviewer attention

- The only modified lines in the branch are the two `:license` values and one
  removed `.gitignore` entry. Every other change is an added line.
- Five files open with an Emacs `;; -*-lisp-*-` modeline. In those the modeline
  keeps line 1 and the identifier goes to line 2, because Emacs looks for the
  `-*-` modeline on the first line. The other 37 take line 1.
- `auth-routes.lisp` is byte identical to its previous state apart from the
  added line.
- Three `.lisp` files are deliberately excluded, being serialized runtime state
  rather than source: `.playback-state.lisp`, `data/sessions/sessions.lisp` and
  `docker/radiance-default.conf.lisp`.
- ECL's `.fas` and `.fasb` remain uncovered by the ignore list. Out of scope
  here, and a one-line follow-up if it is wanted.

## Testing

`asteroid-tests` passes under SBCL at `ec8a7b5`: 14 tests, 65 assertions, 0
failures, 0 skips. Loading the system requires `(setf (radiance:environment)
"asteroid")` beforehand, which is the guard Radiance imposes rather than
anything this branch introduces.

Given its scope, a pass shows the added lines did not disturb loading or
compilation. The suite is entirely pure-function and in-memory hash-table tests,
so it never reaches Postgres or the schema. It is not coverage of the station.

🄯 Brian O'Reilly <fade@deepsky.com>, 2026
