### PR TITLE
chore: ignore ECL build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.ufasl
 *.cfasl
 *.x86f
+*.fas
+*.fasb
 *.lisp-temp
 .asdf-cache/
 *.dfsl


### PR DESCRIPTION
## What changed

`.gitignore` gains `*.fas` and `*.fasb`.

## Why

ECL compiles to `.fas`, and ASDF's bundle operations produce `.fasb` for it.
Neither was covered, so either one compiled in the working tree shows up as an
untracked file. The list already covers SBCL (`*.fasl`), CCL (the `*fsl`
family) and CMUCL (`*.x86f`); this extends it to ECL.

## Reviewer attention

- No tracked file matches either pattern, so nothing currently in the
  repository becomes ignored by this change.
- ECL also emits `.o` object files, left uncovered deliberately. `*.o` is a
  generic C object pattern, and under ASDF's default output translations ECL's
  objects land in the user cache rather than in the tree. Worth revisiting only
  if in-tree builds become a concern.
- An adjacent gap, noticed while checking coverage and not addressed here:
  LispWorks' 64-bit variants (`.64ufasl`, `.64nfasl`) are not matched by the
  existing `*.ufasl` entry.

🄯 Brian O'Reilly <fade@deepsky.com>, 2026
